### PR TITLE
 Change subfield validation

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -56,7 +56,7 @@ export default function ({fields = true, subfields = true, subfieldValues = true
 											},
 											value: {
 												type: 'string',
-												minLength: 1
+												minLength: subfieldValues ? 1 : 0
 											}
 										},
 										required: subfieldValues ? ['code', 'value'] : ['code']


### PR DESCRIPTION
Always require subfields to have code and value properties, but the length of value can be zero if `subfieldValues` validation option is set to false.