### PR TITLE
Fix double 007 bug

### DIFF
--- a/src/marcFieldSort.js
+++ b/src/marcFieldSort.js
@@ -262,7 +262,7 @@ export function fieldOrderComparator(fieldA, fieldB) {
 
 
   function fieldHasSubfield(subcode, value) {
-    return (field) => field.subfields
+    return (field) => field.subfields && field.subfields
       .filter(subfield => subcode === subfield.code)
       .some(subfield => subfield.value === value);
   }

--- a/test-fixtures/index/insertFields/03/metadata.json
+++ b/test-fixtures/index/insertFields/03/metadata.json
@@ -30,7 +30,9 @@
       {"tag": "003", "value": "bar"},
       {"tag": "004", "value": "bar"},
       {"tag": "005", "value": "bar"},
-      {"tag": "006", "value": "bar"}
+      {"tag": "006", "value": "bar"},
+      {"tag": "007", "value": "t|"},
+      {"tag": "007", "value": "qu"}
     ]
   }
 }

--- a/test-fixtures/index/insertFields/03/metadata.json
+++ b/test-fixtures/index/insertFields/03/metadata.json
@@ -15,7 +15,9 @@
       [
         {"tag": "004", "value": "bar"},
         {"tag": "002", "value": "bar"},
-        {"tag": "006", "value": "bar"}
+        {"tag": "006", "value": "bar"},
+        {"tag": "007", "value": "t|"},
+        {"tag": "007", "value": "qu"}
       ]
     }
   ],


### PR DESCRIPTION
Edellinen versio kaatuu, kun siihen yritti lisätä kahta 007-kenttää. Syy: Se yritti käyttää 007-kontrollikenttien olemattomia osakenttiä kenttien sorttauksessa tyyliin field.subfields.filter(...) ja subfields undefined. Tämä versio sisältää ton estävän sanity checkin..

Muu huomio/diskuteerauksen aihe: fennikeepin lisäksi ohjelma voisi preferoida myös FIKKA<KEEP>- ja VIOLA<KEEP>-$9-osakenttiä, eikös?

