### PR TITLE
Tune fennikeep sorting

### DIFF
--- a/src/marcFieldSort.js
+++ b/src/marcFieldSort.js
@@ -193,19 +193,23 @@ export function fieldOrderComparator(fieldA, fieldB) {
     return 0;
   }
 
-  function preferFenniKeep(fieldA, fieldB) {
-    const fenniKeepSelector = fieldHasSubfield('9', 'FENNI<KEEP>');
-    const hasFENNI9A = fenniKeepSelector(fieldA);
-    const hasFENNI9B = fenniKeepSelector(fieldB);
+  function preferKeep(fieldA, fieldB, keepOwner = 'FENNI') {
+    const keepSelector = fieldHasSubfield('9', `${keepOwner}<KEEP>`);
+    const hasKeepA = keepSelector(fieldA);
+    const hasKeepB = keepSelector(fieldB);
 
-    if (hasFENNI9A && !hasFENNI9B) {
+    if (hasKeepA && !hasKeepB) {
       return -1;
     }
-    if (!hasFENNI9A && hasFENNI9B) {
+    if (!hasKeepA && hasKeepB) {
       return 1;
     }
 
     return 0;
+  }
+
+  function preferFenniKeep(fieldA, fieldB) {
+    return preferKeep(fieldA, fieldB, 'FENNI');
   }
 
   function sortAlphabetically(fieldA, fieldB) {
@@ -262,10 +266,17 @@ export function fieldOrderComparator(fieldA, fieldB) {
 
 
   function fieldHasSubfield(subcode, value) {
+
+    /*
     return (field) => field.subfields && field.subfields
       .filter(subfield => subcode === subfield.code)
       .some(subfield => subfield.value === value);
+      */
+    return (field) => field.subfields && field.subfields
+      .some(subfield => subcode === subfield.code && subfield.value === value);
+
   }
+  //return (field) => field.subfields && field.subfields.filter(subfield => subcode === subfield.code && subfield.value === value);
 
 
   function selectFirstValue(field, subcode) {

--- a/src/marcFieldSort.js
+++ b/src/marcFieldSort.js
@@ -209,7 +209,15 @@ export function fieldOrderComparator(fieldA, fieldB) {
   }
 
   function preferFenniKeep(fieldA, fieldB) {
-    return preferKeep(fieldA, fieldB, 'FENNI');
+    const fenniPreference = preferKeep(fieldA, fieldB, 'FENNI');
+    if (fenniPreference !== 0) {
+      return fenniPreference;
+    }
+    const violaPreference = preferKeep(fieldA, fieldB, 'VIOLA');
+    if (violaPreference !== 0) {
+      return violaPreference;
+    }
+    return preferKeep(fieldA, fieldB, 'FIKKA');
   }
 
   function sortAlphabetically(fieldA, fieldB) {

--- a/src/marcFieldSort.js
+++ b/src/marcFieldSort.js
@@ -274,19 +274,12 @@ export function fieldOrderComparator(fieldA, fieldB) {
 
 
   function fieldHasSubfield(subcode, value) {
-
-    /*
-    return (field) => field.subfields && field.subfields
-      .filter(subfield => subcode === subfield.code)
-      .some(subfield => subfield.value === value);
-      */
     return (field) => field.subfields && field.subfields
       .some(subfield => subcode === subfield.code && subfield.value === value);
 
   }
-  //return (field) => field.subfields && field.subfields.filter(subfield => subcode === subfield.code && subfield.value === value);
 
-
+  
   function selectFirstValue(field, subcode) {
     return field.subfields
       .filter(subfield => subcode === subfield.code)

--- a/src/marcFieldSort.js
+++ b/src/marcFieldSort.js
@@ -276,10 +276,8 @@ export function fieldOrderComparator(fieldA, fieldB) {
   function fieldHasSubfield(subcode, value) {
     return (field) => field.subfields && field.subfields
       .some(subfield => subcode === subfield.code && subfield.value === value);
-
   }
 
-  
   function selectFirstValue(field, subcode) {
     return field.subfields
       .filter(subfield => subcode === subfield.code)

--- a/test-fixtures/marcFieldSort/07/input.json
+++ b/test-fixtures/marcFieldSort/07/input.json
@@ -1,0 +1,21 @@
+{
+  "leader": "12345cam a22002417i 4500",
+  "fields":
+  [
+    {"tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      {"code": "a", "value": "eka" }
+    ]},
+    {"tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      {"code": "a", "value": "toka" },
+      {"code": "9", "value": "FIKKA<KEEP>"}
+    ]},
+    {"tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      {"code": "a", "value": "kolmas" },
+      {"code": "9", "value": "VIOLA<KEEP>"}
+    ]},
+    {"tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      {"code": "a", "value": "neljäs" },
+      {"code": "9", "value": "FENNI<KEEP>"}
+    ]}
+  ]
+}

--- a/test-fixtures/marcFieldSort/07/metadata.json
+++ b/test-fixtures/marcFieldSort/07/metadata.json
@@ -1,0 +1,4 @@
+{
+  "description": "Field 650 sort by FENNI<KEEP>",
+  "skip": false
+}

--- a/test-fixtures/marcFieldSort/07/result.json
+++ b/test-fixtures/marcFieldSort/07/result.json
@@ -1,0 +1,21 @@
+{
+  "leader": "12345cam a22002417i 4500",
+  "fields":
+  [
+    {"tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      {"code": "a", "value": "neljäs" },
+      {"code": "9", "value": "FENNI<KEEP>"}
+    ]},
+    {"tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      {"code": "a", "value": "kolmas" },
+      {"code": "9", "value": "VIOLA<KEEP>"}
+    ]},
+    {"tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      {"code": "a", "value": "toka" },
+      {"code": "9", "value": "FIKKA<KEEP>"}
+    ]},
+    {"tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      {"code": "a", "value": "eka" }
+    ]}
+  ]
+}


### PR DESCRIPTION
Support more complex $9-based sort order: now FENNI > VIOLA > FIKKA > none. Also minor simplification to old code.